### PR TITLE
Add customizable loader timings

### DIFF
--- a/src/config/GameConfig.ts
+++ b/src/config/GameConfig.ts
@@ -21,6 +21,13 @@ export interface UIConfig {
     };
 }
 
+export interface LoaderDurations {
+    minDisplayTime: number;
+    transitionTo100: number;
+    holdAfter100: number;
+    fadeOut: number;
+}
+
 export class GameConfig {
     // Reference resolution - all sizes are designed for this resolution
     public static readonly REFERENCE_RESOLUTION: ResolutionConfig = {
@@ -75,19 +82,26 @@ export class GameConfig {
         visibleRows: 3,                // Number of visible rows (inside mask)
         rowsAboveMask: 1,              // Number of rows above visible area
         rowsBelowMask: 1,              // Number of rows below visible area
-        totalRows: function() { 
-            return this.visibleRows + this.rowsAboveMask + this.rowsBelowMask; 
+        totalRows: function () {
+            return this.visibleRows + this.rowsAboveMask + this.rowsBelowMask;
         }
+    };
+
+    public static readonly LOADER_DEFAULT_TIMINGS: LoaderDurations = {
+        minDisplayTime: 600,
+        transitionTo100: 500,
+        holdAfter100: 150,
+        fadeOut: 50
     };
 
     // Calculate scale factors based on current resolution
     public static getScaleFactors(currentWidth: number, currentHeight: number) {
         const scaleX = currentWidth / this.REFERENCE_RESOLUTION.width;
         const scaleY = currentHeight / this.REFERENCE_RESOLUTION.height;
-        
+
         // Use uniform scaling (smaller of the two scales to maintain aspect ratio and prevent distortion)
         const uniformScale = Math.min(scaleX, scaleY);
-        
+
         return {
             scaleX,
             scaleY,
@@ -98,7 +112,7 @@ export class GameConfig {
     // Get scaled symbol size for current resolution
     public static getScaledSymbolSize(currentWidth: number, currentHeight: number): SymbolConfig {
         const { uniformScale } = this.getScaleFactors(currentWidth, currentHeight);
-        
+
         return {
             width: Math.round(this.REFERENCE_SYMBOL.width * uniformScale),
             height: Math.round(this.REFERENCE_SYMBOL.height * uniformScale),
@@ -108,7 +122,7 @@ export class GameConfig {
 
     public static getReferenceSymbolScale(currentWidth: number, currentHeight: number): number[] {
         const { uniformScale } = this.getScaleFactors(currentWidth, currentHeight);
-        const scaleX = this.REFERENCE_SYMBOL.width / this.REFERENCE_SYMBOL_TEXTURE_SIZE.width * uniformScale;  
+        const scaleX = this.REFERENCE_SYMBOL.width / this.REFERENCE_SYMBOL_TEXTURE_SIZE.width * uniformScale;
         const scaleY = this.REFERENCE_SYMBOL.height / this.REFERENCE_SYMBOL_TEXTURE_SIZE.height * uniformScale;
         return [scaleX, scaleY];
     }
@@ -116,7 +130,7 @@ export class GameConfig {
     // Get scaled UI config for current resolution
     public static getScaledUI(currentWidth: number, currentHeight: number): UIConfig {
         const { uniformScale } = this.getScaleFactors(currentWidth, currentHeight);
-        
+
         return {
             fontSize: {
                 title: Math.round(this.REFERENCE_UI.fontSize.title * uniformScale),
@@ -133,7 +147,7 @@ export class GameConfig {
     // Get resolution category for debugging/optimization
     public static getResolutionCategory(width: number, height: number): string {
         const pixels = width * height;
-        
+
         if (pixels >= 3840 * 2160) return '4K+';
         if (pixels >= 2560 * 1440) return '1440p';
         if (pixels >= 1920 * 1080) return '1080p';

--- a/src/engine/utils/Loader.ts
+++ b/src/engine/utils/Loader.ts
@@ -1,13 +1,19 @@
 import { Application, Container, Graphics, Text } from "pixi.js";
-import { signals, SCREEN_SIGNALS } from '../controllers/SignalManager';
+import { signals, SCREEN_SIGNALS } from "../controllers/SignalManager";
 import { gsap } from "gsap";
 import { debug } from "./debug";
 
 export class Loader extends Container {
     private static _instance: Loader;
     private app?: Application;
+
     private smooth = { percent: 0 };
-    private onLoaded!: (itemName: string, progress: number) => void;
+    private startedAt = 0;
+    private minDisplayTime = 900;
+    private transitionTo100 = 600;
+    private holdAfter100 = 350;
+    private fadeOut = 300;
+
     private completionPromise: Promise<void>;
     private resolveCompletion!: () => void;
 
@@ -15,33 +21,17 @@ export class Loader extends Container {
     private fill!: Graphics;
     private percentageLabel!: Text;
     private progressStatus!: Text;
-
+    
     private barWidth: number = 450;
     private barHeight: number = 26;
     private padding: number = 4;
 
     private constructor() {
         super();
-        this.completionPromise = new Promise<void>(resolve => (this.resolveCompletion = resolve));
 
-        this.onLoaded = async (label: string, percent: number) => {
-            debug.log("Loader", `${label} is loading...`);
-            this.tweenToPercent(percent);
-
-            this.progressStatus.text = `Loading ${label}...`;
-
-            if (label === "completed") {
-                await this.completeProgress();
-            }
-        };
-
-        signals.on(SCREEN_SIGNALS.ASSETS_LOADED, (data: any) => {
-            // If data is an array [label, percent], destructure it
-            // If data is an object { label, percent }, access properties
-            // Adjust according to SignalManager emit implementation
-            const [label, percent] = Array.isArray(data) ? data : [data.label, data.percent];
-            this.onLoaded(label, percent);
-        });
+        this.completionPromise = new Promise<void>((resolve) => (this.resolveCompletion = resolve));
+        
+        signals.on(SCREEN_SIGNALS.ASSETS_LOADED, this.handleAssetsLoaded);
     }
 
     public static getInstance(): Loader {
@@ -82,6 +72,22 @@ export class Loader extends Container {
         this.addChild(this.progressStatus);
     }
 
+    private onLoaded(label: string, percent: number) {
+        debug.log("Loader", `${label} is loading...`);
+        this.tweenToPercent(percent);
+        this.progressStatus.text = `Loading ${label}...`;
+
+        if (label === "completed") {
+            void this.completeProgress();
+        }
+    }
+
+    // reference of handler (for unsubscribe)
+    private handleAssetsLoaded = (data: any) => {
+        const [label, percent] = Array.isArray(data) ? data : [data.label, data.percent];
+        this.onLoaded(label as string, percent as number);
+    };
+
     private redrawFill(ratio01: number) {
         const clamped = Math.max(0, Math.min(1, ratio01));
         const width = clamped * (this.barWidth - this.padding * 2);
@@ -108,7 +114,7 @@ export class Loader extends Container {
             (app.screen.height - this.barHeight) / 2
         );
 
-        // pulse animation
+        // pulse effect
         gsap.to(this.fill, {
             alpha: 0.5,
             duration: 0.25,
@@ -116,6 +122,8 @@ export class Loader extends Container {
             yoyo: true,
             repeat: -1
         });
+
+        this.startedAt = performance.now();
     }
 
     public unmount() {
@@ -126,7 +134,7 @@ export class Loader extends Container {
 
         gsap.killTweensOf(this.smooth);
         gsap.killTweensOf(this.fill);
-        // event off
+        // remove event listeners
         signals.off(SCREEN_SIGNALS.ASSETS_LOADED);
         Loader._instance = null as any;
         this.destroy({ children: true });
@@ -154,14 +162,34 @@ export class Loader extends Container {
     }
 
     public async completeProgress(): Promise<void> {
-        if (this.smooth.percent < 100) {
-            this.setPercent(100);
+        const elapsed = performance.now() - this.startedAt;
+        const waitMs = Math.max(0, this.minDisplayTime - elapsed);
+        if (waitMs > 0) await new Promise((resolve) => setTimeout(resolve, waitMs));
+
+        await new Promise<void>((resolve) => {
+            gsap.to(this.smooth, {
+                percent: 100,
+                duration: this.transitionTo100 / 1000,
+                ease: "power2.out",
+                onUpdate: () => {
+                    const ratio = this.smooth.percent / 100;
+                    this.redrawFill(ratio);
+                    this.percentageLabel.text = `${Math.round(this.smooth.percent)}%`;
+                },
+                onComplete: resolve,
+            });
+        });
+
+        // wait a bit after reaching 100%
+        if (this.holdAfter100 > 0) {
+            await new Promise((resolve) => setTimeout(resolve, this.holdAfter100));
         }
 
+        // fade-out + close
         await new Promise<void>((resolve) => {
             gsap.to(this, {
                 alpha: 0,
-                duration: 0.25,
+                duration: this.fadeOut / 1000,
                 ease: "none",
                 onComplete: () => {
                     this.unmount();
@@ -185,5 +213,10 @@ export class Loader extends Container {
 
     public get progress(): Promise<void> {
         return this.completionPromise;
+    }
+
+    // we can easily adjust these timings from the outside if we want
+    public setTimings(opts: Partial<{ minDisplayTime: number; transitionTo100: number; holdAfter100: number; fadeOut: number }>) {
+        Object.assign(this, opts);
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { SpinResponseData, CascadeStepData, InitialGridData, ISpinState } from '
 import { Background } from './engine/Background';
 import { AssetLoader } from './engine/utils/AssetLoader';
 import { AssetsConfig } from './config/AssetsConfig';
+import { GameConfig } from './config/GameConfig';
 import { Loader } from './engine/utils/Loader';
 
 export class DoodleV8Main {
@@ -191,6 +192,8 @@ export class DoodleV8Main {
         const loader = Loader.getInstance();
         loader.init();
         loader.mount(this.app);
+        // set custom loader timings (milliseconds)
+        loader.setTimings(GameConfig.LOADER_DEFAULT_TIMINGS);
         await loader.progress; // Wait for the loader to complete
     }
 


### PR DESCRIPTION
Introduce a `LoaderDurations` interface to define customizable loader timings. Implement these timings in the `Loader` class, allowing for adjustments to display duration, transition, hold, and fade-out times. Update the main application to utilize default loader timings from the `GameConfig`.